### PR TITLE
Fix Canvas section style issues

### DIFF
--- a/src/components/Canvas/Canvas.css
+++ b/src/components/Canvas/Canvas.css
@@ -14,7 +14,7 @@
 
 .recipient-input-container {
   flex: 2;
-  margin-right: 50px;
+  margin-right: 70px;
 }
 
 .input {
@@ -27,19 +27,18 @@
 .msg-options {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-end;
   margin-bottom: 10px;
 }
 
 #message-body {
   width: 100%;
   font-family: "Arial";
-  height: 120px;
 }
 
 .color-input-container {
-  flex: 1;
-  margin-right: 50px;
+  flex: 1.3;
+  margin-right: 70px;
 }
 
 input:focus,
@@ -52,7 +51,9 @@ select:focus {
   border: none;
   border-radius: 3px;
   margin-top: 7px;
-  padding: 12px 40px;
+  margin-bottom: 2px;
+  height: 42px;
+  width: 120px;
   font-size: 20px;
   color: #fff;
   text-transform: uppercase;
@@ -75,8 +76,10 @@ select:focus {
 }
 
 .errorMessage {
-  margin: 0 0 8px 16px;
+  margin-bottom: 6px;
+  margin-left: 1px;
   color: rgb(10, 4, 61);
+  font-size: 14px;
 }
 
 .flex-column {

--- a/src/components/Canvas/Canvas.css
+++ b/src/components/Canvas/Canvas.css
@@ -1,47 +1,45 @@
 .canvas-container {
   width: 100%;
-  height: 300px;
+  flex: 5;
   display: flex;
   justify-content: center;
-  padding: 40px 0;
-  background-color: #0092d3;
+  align-items: center;
 }
 
 #msg-form {
-  width: 50%;
+  width: 80%;
   margin-right: 20px;
+  max-width: 900px;
 }
 
-.msg-options {
-  margin-bottom: 10px;
-}
-
-#recipient-input {
-
-  width: 60%;
-  margin-right: 8px;
-
+.recipient-input-container {
+  flex: 2;
+  margin-right: 50px;
 }
 
 .input {
   border: none;
   border-radius: 3px;
   padding: 10px;
-  font-size: 20px;
+  font-size: 18px;
 }
 
 .msg-options {
   display: flex;
   justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
 }
 
 #message-body {
   width: 100%;
   font-family: "Arial";
+  height: 120px;
 }
 
-#color-input {
-  width: 40%;
+.color-input-container {
+  flex: 1;
+  margin-right: 50px;
 }
 
 input:focus,
@@ -52,6 +50,7 @@ select:focus {
 
 .sendButton {
   border: none;
+  border-radius: 3px;
   margin-top: 7px;
   padding: 12px 40px;
   font-size: 20px;
@@ -94,8 +93,3 @@ select:focus {
   }
 }
 
-/* @media (max-width: 767px) {
-  .sendButton {
-    padding: 10px 15px;
-  }
-} */

--- a/src/components/Canvas/Canvas.js
+++ b/src/components/Canvas/Canvas.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import "./Canvas.css";
 
 const Canvas = ({ setNewShoutout, sendShoutout, newShoutout }) => {
-  const { recipient, color, message } = newShoutout;
+  const { recipient, color, text } = newShoutout;
   const errorBaseState = { isError: false, message: "" };
   const [recipientError, setRecipientError] = useState(errorBaseState);
   const [colorError, setColorError] = useState(errorBaseState);
@@ -16,7 +16,6 @@ const Canvas = ({ setNewShoutout, sendShoutout, newShoutout }) => {
   };
 
   const handleClick = (e) => {
-    console.log(color)
     if (!recipient) {
       setRecipientError({
         isError: true,
@@ -26,14 +25,14 @@ const Canvas = ({ setNewShoutout, sendShoutout, newShoutout }) => {
     if (!color || color === "Color") {
       setColorError({ isError: true, message: "Let's make it POP!" });
     }
-    if (!message) {
+    if (!text) {
       setMessageError({
         isError: true,
         message: "Don't toy with our hearts. Let the good vibes roll!",
       });
     }
 
-    if (!recipient || !color ||  color === "Color" || !message) {
+    if (!recipient || !color || color === "Color" || !text) {
       return;
     } else {
       setRecipientError(errorBaseState);
@@ -92,31 +91,31 @@ const Canvas = ({ setNewShoutout, sendShoutout, newShoutout }) => {
               <option value="purple">Purple</option>
             </select>
           </div>
-        <div className="flex-column">
-        <button
-          className="sendButton"
-          onClick={handleClick}
-        >
-          Send
+          <div className="flex-column">
+            <button
+              className="sendButton"
+              onClick={handleClick}
+            >
+              Send
         </button>
-        </div>
+          </div>
         </div>
         <div className="flex-column">
-        <span className="errorMessage" >{messageError.message}</span>
+          <span className="errorMessage">{messageError.message}</span>
           <textarea
             id="message-body"
             className="input"
-            rows="5"
+            rows="4"
             placeholder="Type a message..."
-            name="message"
-            value={message}
+            name="text"
+            value={text}
             onChange={handleInputChange}
             onKeyPress={(event) =>
               event.key === "Enter" ? sendShoutout(event) : null
             }
             onBlur={() => {
               setMessageError(
-                !message
+                !text
                   ? {
                     isError: true,
                     message: "Let everyone know who your praising!",

--- a/src/components/Canvas/Canvas.js
+++ b/src/components/Canvas/Canvas.js
@@ -23,7 +23,7 @@ const Canvas = ({ setNewShoutout, sendShoutout, newShoutout }) => {
         message: "Give name to the hero!",
       });
     }
-    if (!color || color === "Background Color") {
+    if (!color || color === "Color") {
       setColorError({ isError: true, message: "Let's make it POP!" });
     }
     if (!message) {
@@ -33,7 +33,7 @@ const Canvas = ({ setNewShoutout, sendShoutout, newShoutout }) => {
       });
     }
 
-    if (!recipient || !color ||  color === "Background Color" || !message) {
+    if (!recipient || !color ||  color === "Color" || !message) {
       return;
     } else {
       setRecipientError(errorBaseState);
@@ -47,11 +47,10 @@ const Canvas = ({ setNewShoutout, sendShoutout, newShoutout }) => {
     <div className="canvas-container">
       <section className="canvas-section" id="msg-form">
         <div className="msg-options">
-          <div className="flex-column">
+          <div className="flex-column recipient-input-container">
             <span className="errorMessage" >{recipientError.message}</span>
             <input
               id="recipient-input"
-              // style={recipientError.isError ? { border: "3px solid red" } : null}
               className="input"
               name="recipient"
               type="text"
@@ -68,12 +67,11 @@ const Canvas = ({ setNewShoutout, sendShoutout, newShoutout }) => {
               }}
             />
           </div>
-          <div className="flex-column">
+          <div className="flex-column color-input-container">
             <span className="errorMessage" >{colorError.message}</span>
             <select
               className="input"
               id="color-input"
-              // style={colorError.isError ? { border: "3px solid red" } : null}
               name="color"
               onChange={handleInputChange}
               value={color}
@@ -84,7 +82,7 @@ const Canvas = ({ setNewShoutout, sendShoutout, newShoutout }) => {
                 } : errorBaseState);
               }}
             >
-              <option>Background Color</option>
+              <option>Color</option>
 
               <option value="red">Red</option>
               <option value="orange">Orange</option>
@@ -98,18 +96,16 @@ const Canvas = ({ setNewShoutout, sendShoutout, newShoutout }) => {
         <button
           className="sendButton"
           onClick={handleClick}
-          // disabled={disabled}
         >
           Send
         </button>
         </div>
         </div>
         <div className="flex-column">
-          <span className="errorMessage" >{messageError.message}</span>
+        <span className="errorMessage" >{messageError.message}</span>
           <textarea
             id="message-body"
             className="input"
-            // style={messageError.isError ? { border: "3px solid red" } : null}
             rows="5"
             placeholder="Type a message..."
             name="message"
@@ -129,9 +125,6 @@ const Canvas = ({ setNewShoutout, sendShoutout, newShoutout }) => {
             }}
           />
         </div>
-      </section>
-      <section className="canvas-section">
-       
       </section>
     </div>
   );

--- a/src/components/Chat/Chat.css
+++ b/src/components/Chat/Chat.css
@@ -21,7 +21,7 @@
   background-color: rgba(50, 146, 210, 0.8);
   display: flex;
   align-items: center;
-  height: 270px;
+  height: 230px;
   padding: 0 100px;
 }
 

--- a/src/components/Chat/Chat.css
+++ b/src/components/Chat/Chat.css
@@ -20,7 +20,8 @@
 #canvasAndDogHouseContainer {
   background-color: rgba(50, 146, 210, 0.8);
   display: flex;
-  height: 175px;
+  align-items: center;
+  height: 270px;
   padding: 0 100px;
 }
 

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -17,7 +17,7 @@ const Chat = () => {
     color: "",
     id: "",
     recipient: "",
-    message: "",
+    text: "",
     variant: "shoutout",
   };
 

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -33,7 +33,7 @@ const Chat = () => {
     setShouldDropConfetti(true);
     setTimeout(() => {
       setShouldDropConfetti(false);
-    }, 5000); //this time can be adjusted, but it seems about right to account for the confetti "falling off the screen"
+    }, 5000);
   };
 
   const [newShoutout, setNewShoutout] = useState(emptyShoutout);

--- a/src/components/DogHouse/DogHouse.css
+++ b/src/components/DogHouse/DogHouse.css
@@ -1,7 +1,6 @@
 #dogHouseContainer {
   display: flex;
-  height: 175px;
-  max-width: 600px;
+  flex: 1;
   justify-content: center;
 }
 
@@ -18,10 +17,9 @@
 
 #dogImage {
   margin: 4px 4px 4px 0;
-  max-width: 500px;
-  max-height: 175px;
+  max-width: 200px;
+  max-height: 200px;
 }
-
 
 @media (max-width: 767px) {
   #dogHouseContainer {

--- a/src/components/MessageList/MessageList.css
+++ b/src/components/MessageList/MessageList.css
@@ -12,5 +12,5 @@
 }
 
 div.messageItem:last-of-type {
-  margin-bottom: 250px;
+  margin-bottom: 315px;
 }

--- a/src/components/MessageList/MessageList.css
+++ b/src/components/MessageList/MessageList.css
@@ -12,5 +12,5 @@
 }
 
 div.messageItem:last-of-type {
-  margin-bottom: 315px;
+  margin-bottom: 280px;
 }

--- a/src/components/Shoutout/Shoutout.jsx
+++ b/src/components/Shoutout/Shoutout.jsx
@@ -31,7 +31,7 @@ const Emoji = ({ id, label, symbol, handleConfetti }) => {
   }
 
   useEffect(() => {
-    if(emojiCount === 2) { //We will want to change this to be a better number, but this makes it is easy to test
+    if(emojiCount === 10) {
       handleConfetti();
     }
   }, [emojiCount])


### PR DESCRIPTION
Conflicting styles in recent merges created some issues in the bottom section, mostly related to Canvas. These included overlapping transparent background colors, different height for different elements, and narrow inputs (among others). Also noticed that the 'text' property of the Shoutout object was changed to 'message' in some places, which broke functionality, so that was reverted here.